### PR TITLE
Link to SOR V2 documentation

### DIFF
--- a/smart-contracts/sor/README.md
+++ b/smart-contracts/sor/README.md
@@ -1,6 +1,6 @@
 # Smart Order Router
 
-## This page has been deprecated. V1 documentation is partially maintained [here](https://docs.balancer.fi/v/v1/smart-contracts/sor/)
+## This page has been deprecated. SOR V2 documentation is [here](https://docs.balancer.fi/developers/smart-order-router). V1 documentation is partially maintained [here](https://docs.balancer.fi/v/v1/smart-contracts/sor/). 
 
 ## Smart Order Router
 


### PR DESCRIPTION
The Smart Order Router README links to this docs page which then says it's deprecated with no links to the new docs. Adding a link to SOR V2 docs.